### PR TITLE
Fixes #22 Added Background Video for Small Screens and Increase Cell Opacity

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -5,11 +5,22 @@ body {
   align-items: center;
   height: 100vh;
   background: url("https://blenderartists.org/uploads/default/original/4X/0/5/f/05fb495b0f4ce4fb15ddc0cd136250a6aaae67c2.jpeg")
-    no-repeat center center fixed;
-  background-size: cover; /* This makes the image cover the entire background */
+  no-repeat center center fixed;
+  background-size: cover; /*This makes the image cover the entire background*/
   font-family: "Arial", sans-serif;
   color: #fff;
 }
+
+#backgroundVideo {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  z-index: -1; /* Ensures the video stays behind other content */
+}
+
 
 /* Rest of your CSS remains unchanged */
 
@@ -44,7 +55,7 @@ body {
   width: 100px;
   height: 100px;
 
-  background-color: rgba(255, 255, 255, 0.1);
+  background-color: rgba(255, 255, 255, 0.3);
   border: 2px solid rgba(255, 255, 255, 0.3);
   border-radius: 10px;
   display: flex;
@@ -70,12 +81,12 @@ body {
 }
 
 .cell:hover {
-  background-color: rgba(255, 255, 255, 0.2);
+  background-color: rgba(255, 255, 255, 0.463);
   transform: scale(1.05);
 }
 #result {
   margin-top: 20px;
-  font-size: 1.5em;
+  font-size: 1.7em;
   text-align: center;
   animation: glow 1.5s infinite alternate;
   color: #ff007f;
@@ -144,11 +155,12 @@ body {
   body {
     height: auto;
     padding: 20px;
-    background-size: cover;
+    background:none;
     display:block;
   }
 
   #gameBoard {
+    
     grid-template-columns: repeat(3, 70px);
     grid-template-rows: repeat(3, 70px);
     gap: 5px;
@@ -188,7 +200,7 @@ body {
   body {
     height: auto;
     padding: 20px;
-    background-size: cover;
+    background:none;
   }
 
   #gameBoard {
@@ -227,6 +239,9 @@ body {
     height: 100vh;
     padding: 0;
     background-size: cover;
+  }
+  #backgroundVideo {
+    display: none;
   }
 
   #gameBoard {

--- a/index.html
+++ b/index.html
@@ -7,6 +7,12 @@
 
   </head>
   <body>
+     <!-- Background Video -->
+  <video autoplay muted loop id="backgroundVideo">
+    <source src="/tictac.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+
     <div class="currentPlayer">
       <div id="currentPlayer">Current Player: X</div>
     </div class="content">


### PR DESCRIPTION
Fixes #22 
Description:

- Added a background video specifically for screen sizes less than 768px to enhance visual appeal on smaller devices.

- Increased the opacity of the game cells to ensure that the background video doesn’t interfere with the visibility of the X and O markers.

Preview:


![Screenshot 2024-10-25 141729](https://github.com/user-attachments/assets/ee6c0e05-9975-41f4-b4d6-a7c893cdc6c2)

https://github.com/user-attachments/assets/98744ad7-47c3-4d30-92dc-00f5a7674ab6







